### PR TITLE
[openssh] add inspec tests

### DIFF
--- a/attributes.yml
+++ b/attributes.yml
@@ -1,1 +1,2 @@
-command_path: '/sbin/sshd'
+command_relative_path: 'sbin/sshd'
+listening_port: '2222'

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+command_path: '/sbin/sshd'

--- a/config/sshd_config
+++ b/config/sshd_config
@@ -1,0 +1,133 @@
+#	$OpenBSD: sshd_config,v 1.98 2016/02/17 05:29:04 djm Exp $
+
+# This is the sshd server system-wide configuration file.  See
+# sshd_config(5) for more information.
+
+# This sshd was compiled with PATH=/usr/bin:/bin:/usr/sbin:/sbin
+
+# The strategy used for options in the default sshd_config shipped with
+# OpenSSH is to specify options with their default value where
+# possible, but leave them commented.  Uncommented options override the
+# default value.
+
+Port {{cfg.port}}
+#AddressFamily any
+#ListenAddress 0.0.0.0
+#ListenAddress ::
+
+# The default requires explicit activation of protocol 1
+#Protocol 2
+
+# HostKey for protocol version 1
+#HostKey /etc/ssh/ssh_host_key
+# HostKeys for protocol version 2
+HostKey {{pkg.svc_config_path}}/ssh_host_rsa_key
+HostKey {{pkg.svc_config_path}}/ssh_host_dsa_key
+HostKey {{pkg.svc_config_path}}/ssh_host_ecdsa_key
+HostKey {{pkg.svc_config_path}}/ssh_host_ed25519_key
+
+# Lifetime and size of ephemeral version 1 server key
+#KeyRegenerationInterval 1h
+#ServerKeyBits 1024
+
+# Ciphers and keying
+#RekeyLimit default none
+
+# Logging
+# obsoletes QuietMode and FascistLogging
+#SyslogFacility AUTH
+#LogLevel INFO
+
+# Authentication:
+
+#LoginGraceTime 2m
+#PermitRootLogin prohibit-password
+#StrictModes yes
+#MaxAuthTries 6
+#MaxSessions 10
+
+#RSAAuthentication yes
+PubkeyAuthentication {{cfg.pubkey_authentication}}
+
+# The default is to check both .ssh/authorized_keys and .ssh/authorized_keys2
+# but this is overridden so installations will only check .ssh/authorized_keys
+AuthorizedKeysFile	.ssh/authorized_keys
+
+#AuthorizedPrincipalsFile none
+
+#AuthorizedKeysCommand none
+#AuthorizedKeysCommandUser nobody
+
+# For this to work you will also need host keys in /etc/ssh/ssh_known_hosts
+#RhostsRSAAuthentication no
+# similar for protocol version 2
+#HostbasedAuthentication no
+# Change to yes if you don't trust ~/.ssh/known_hosts for
+# RhostsRSAAuthentication and HostbasedAuthentication
+#IgnoreUserKnownHosts no
+# Don't read the user's ~/.rhosts and ~/.shosts files
+#IgnoreRhosts yes
+
+# To disable tunneled clear text passwords, change to no here!
+PasswordAuthentication {{cfg.password_authentication}}
+#PermitEmptyPasswords no
+
+# Change to no to disable s/key passwords
+#ChallengeResponseAuthentication yes
+
+# Kerberos options
+#KerberosAuthentication no
+#KerberosOrLocalPasswd yes
+#KerberosTicketCleanup yes
+#KerberosGetAFSToken no
+
+# GSSAPI options
+#GSSAPIAuthentication no
+#GSSAPICleanupCredentials yes
+
+# Set this to 'yes' to enable PAM authentication, account processing,
+# and session processing. If this is enabled, PAM authentication will
+# be allowed through the ChallengeResponseAuthentication and
+# PasswordAuthentication.  Depending on your PAM configuration,
+# PAM authentication via ChallengeResponseAuthentication may bypass
+# the setting of "PermitRootLogin without-password".
+# If you just want the PAM account and session checks to run without
+# PAM authentication, then enable this but set PasswordAuthentication
+# and ChallengeResponseAuthentication to 'no'.
+#UsePAM no
+
+#AllowAgentForwarding yes
+#AllowTcpForwarding yes
+#GatewayPorts no
+#X11Forwarding no
+#X11DisplayOffset 10
+#X11UseLocalhost yes
+#PermitTTY yes
+#PrintMotd yes
+#PrintLastLog yes
+#TCPKeepAlive yes
+#UseLogin no
+#UsePrivilegeSeparation sandbox
+#PermitUserEnvironment no
+#Compression delayed
+#ClientAliveInterval 0
+#ClientAliveCountMax 3
+#UseDNS no
+#PidFile /var/run/sshd.pid
+#MaxStartups 10:30:100
+#PermitTunnel no
+#ChrootDirectory none
+#VersionAddendum none
+
+# no default banner path
+#Banner none
+
+# override default of no subsystems
+Subsystem	sftp	{{cfg.pkg_path}}/libexec/sftp-server
+
+# Example of overriding settings on a per-user basis
+#Match User anoncvs
+#	X11Forwarding no
+#	AllowTcpForwarding no
+#	PermitTTY no
+#	ForceCommand cvs server

--- a/controls/openssh_exists.rb
+++ b/controls/openssh_exists.rb
@@ -1,17 +1,24 @@
 title 'Tests to confirm openssh exists'
 
+plan_origin = ENV['HAB_ORIGIN']
 plan_name = input('plan_name', value: 'openssh')
-plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
-openssh_relative_path = input('command_path', value: '/sbin/sshd')
-openssh_installation_directory = command("hab pkg path #{plan_ident}")
-openssh_full_path = openssh_installation_directory.stdout.strip + "#{ openssh_relative_path}"
- 
+
 control 'core-plans-openssh-exists' do
   impact 1.0
   title 'Ensure openssh exists'
   desc '
-  '
-   describe file(openssh_full_path) do
+  Verify openssh by ensuring bin/sshd exists'
+  
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
+  end
+
+  command_relative_path = input('command_relative_path', value: 'sbin/sshd')
+  command_full_path = File.join(plan_installation_directory.stdout.strip, "#{command_relative_path}")
+  describe file(command_full_path) do
     it { should exist }
   end
 end

--- a/controls/openssh_exists.rb
+++ b/controls/openssh_exists.rb
@@ -1,0 +1,17 @@
+title 'Tests to confirm openssh exists'
+
+plan_name = input('plan_name', value: 'openssh')
+plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
+openssh_relative_path = input('command_path', value: '/sbin/sshd')
+openssh_installation_directory = command("hab pkg path #{plan_ident}")
+openssh_full_path = openssh_installation_directory.stdout.strip + "#{ openssh_relative_path}"
+ 
+control 'core-plans-openssh-exists' do
+  impact 1.0
+  title 'Ensure openssh exists'
+  desc '
+  '
+   describe file(openssh_full_path) do
+    it { should exist }
+  end
+end

--- a/controls/openssh_habservice_works.rb
+++ b/controls/openssh_habservice_works.rb
@@ -1,0 +1,48 @@
+title 'Tests to confirm openssh habitat service works as expected'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'openssh')
+
+control 'core-plans-openssh-habservice-works' do
+  impact 1.0
+  title 'Ensure openssh habitat service works as expected'
+  desc '
+  Verify openssh habitat service by ensuring that 
+  (1) the default.openssh habitat service is "up"; 
+  (2) the openssh process is LISTENing on the expected port.  Note the 
+  regex that detects the LISTENing <program> works in both a habitat studio environment
+  and a docker one.  In studio the program is displayed as "1234/sshd";
+  whereas in docker as "-".
+  '
+  
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
+  end
+
+  plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+  describe command("hab svc status") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /(?<package>#{plan_pkg_ident})\s+(?<type>standalone)\s+(?<desired>up)\s+(?<state>up)/ }
+    its('stderr') { should be_empty }
+  end
+
+  netstat_installation_directory = command("hab pkg path core/busybox-static")
+  describe netstat_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
+  end
+
+  netstat_fullpath = File.join(netstat_installation_directory.stdout.strip, "bin/netstat" )
+  listening_port=input('listening_port', value: '2222')
+  describe command("#{netstat_fullpath} -peanut") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /:(?<port>#{listening_port}).*LISTEN\s+(?<program>-|\d+\/sshd)/ }
+    its('stderr') { should be_empty }
+  end
+end

--- a/controls/openssh_works.rb
+++ b/controls/openssh_works.rb
@@ -1,47 +1,31 @@
 title 'Tests to confirm openssh works as expected'
 
+plan_origin = ENV['HAB_ORIGIN']
 plan_name = input('plan_name', value: 'openssh')
-plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
-openssh_path = command("hab pkg path #{plan_ident}")
-openssh_pkg_ident = ((openssh_path.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
 
-control 'core-plans-openssh-works-001' do
+control 'core-plans-openssh-works' do
   impact 1.0
-  title 'sshd is the expected version'
+  title 'Ensure openssh works as expected'
   desc '
+  Verify openssh by ensuring 
+  (1) its installation directory exists and 
+  (2) that it returns the expected version.
   '
-
-  describe openssh_path do
+  
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
   end
   
-  describe command("DEBUG=true; hab pkg exec #{openssh_pkg_ident} ssh -V") do
-    its('exit_status') { should eq 0 }
+  command_relative_path = input('command_relative_path', value: 'bin/sshd')
+  command_full_path = File.join(plan_installation_directory.stdout.strip, "#{command_relative_path}")
+  plan_pkg_version = plan_installation_directory.stdout.split("/")[5]
+  describe command("#{command_full_path} -V") do
+    its('exit_status') { should eq 1 }
     its('stdout') { should be_empty }
-    its('stderr') { should match /^OpenSSH_7.5p1/ }
+    its('stderr') { should_not be_empty }
+    its('stderr') { should match /^OpenSSH_#{plan_pkg_version}/ }
   end
 end
-
-control 'core-plans-openssh-works-002' do
-  impact 1.0
-  title 'openssh habitat service is "up"'
-  describe command("hab svc status") do
-    its('exit_status') { should eq 0 }
-    its('stdout') { should_not be_empty }
-    its('stdout') { should match /(?<package>#{openssh_pkg_ident})\s+(?<type>standalone)\s+(?<desired>up)\s+(?<state>up)/ }
-    its('stderr') { should be_empty }
-  end
-end
-
-control 'core-plans-openssh-works-003' do
-  impact 1.0
-  title 'sshd process is running in the background'
-  describe command("hab pkg exec core/busybox-static ps -efl") do
-    its('exit_status') { should eq 0 }
-    its('stdout') { should_not be_empty }
-    its('stdout') { should match /\/hab\/pkgs\/#{openssh_pkg_ident}\/sbin\/sshd -D -f \/hab\/svc\/openssh\/config\/sshd_config/ }
-    its('stderr') { should be_empty }
-  end
-end
-

--- a/controls/openssh_works.rb
+++ b/controls/openssh_works.rb
@@ -1,0 +1,47 @@
+title 'Tests to confirm openssh works as expected'
+
+plan_name = input('plan_name', value: 'openssh')
+plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
+openssh_path = command("hab pkg path #{plan_ident}")
+openssh_pkg_ident = ((openssh_path.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+
+control 'core-plans-openssh-works-001' do
+  impact 1.0
+  title 'sshd is the expected version'
+  desc '
+  '
+
+  describe openssh_path do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+  
+  describe command("DEBUG=true; hab pkg exec #{openssh_pkg_ident} ssh -V") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should be_empty }
+    its('stderr') { should match /^OpenSSH_7.5p1/ }
+  end
+end
+
+control 'core-plans-openssh-works-002' do
+  impact 1.0
+  title 'openssh habitat service is "up"'
+  describe command("hab svc status") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /(?<package>#{openssh_pkg_ident})\s+(?<type>standalone)\s+(?<desired>up)\s+(?<state>up)/ }
+    its('stderr') { should be_empty }
+  end
+end
+
+control 'core-plans-openssh-works-003' do
+  impact 1.0
+  title 'sshd process is running in the background'
+  describe command("hab pkg exec core/busybox-static ps -efl") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /\/hab\/pkgs\/#{openssh_pkg_ident}\/sbin\/sshd -D -f \/hab\/svc\/openssh\/config\/sshd_config/ }
+    its('stderr') { should be_empty }
+  end
+end
+

--- a/default.toml
+++ b/default.toml
@@ -1,0 +1,3 @@
+pubkey_authentication = 'yes'
+password_authentication = 'yes'
+port=2222

--- a/hooks/init
+++ b/hooks/init
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Ensure privileged separation directory is present with
+# correct permissions
+mkdir -p {{pkg.path}}/var/empty
+chmod 0700 {{pkg.path}}/var/empty
+
 # Generate the keys if they do not exist - restarting sshd would cause
 # this to fail, e.g., on package upgrade
 if [ ! -f {{pkg.svc_config_path}}/ssh_host_dsa_key ]; then

--- a/hooks/init
+++ b/hooks/init
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Generate the keys if they do not exist - restarting sshd would cause
+# this to fail, e.g., on package upgrade
+if [ ! -f {{pkg.svc_config_path}}/ssh_host_dsa_key ]; then
+  ssh-keygen -t dsa -f {{pkg.svc_config_path}}/ssh_host_dsa_key -N ""
+fi
+
+if [ ! -f {{pkg.svc_config_path}}/ssh_host_rsa_key ]; then
+  ssh-keygen -t rsa -f {{pkg.svc_config_path}}/ssh_host_rsa_key -N ""
+fi
+
+if [ ! -f {{pkg.svc_config_path}}/ssh_host_ed25519_key ]; then
+  ssh-keygen -t ed25519 -f {{pkg.svc_config_path}}/ssh_host_ed25519_key -N ""
+fi
+
+if [ ! -f {{pkg.svc_config_path}}/ssh_host_ecdsa_key ]; then
+  ssh-keygen -t ecdsa -f {{pkg.svc_config_path}}/ssh_host_ecdsa_key -N ""
+fi

--- a/hooks/run
+++ b/hooks/run
@@ -2,7 +2,4 @@
 
 exec 2>&1
 
-while true; do
-  echo "Sleeping ..."
-  sleep 10
-done
+exec {{pkg.path}}/sbin/sshd -D -f {{pkg.svc_config_path}}/sshd_config

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,9 +1,9 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
-maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
-copyright: humans@habitat.sh
-copyright_email: humans@habitat.sh
+name: openssh
+title: Habitat Core Plan openssh
+maintainer: "The Habitat Maintainers <humans@habitat.sh>"
+summary: InSpec controls for testing Habitat Core Plan openssh
+copyright: 2019, Chef Software, Inc.
+copyright_email: legal@chef.io
 version: 0.1.0
 license: Apache-2.0
 inspec_version: '>= 3.0.25'

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,32 @@
+pkg_origin=core
+pkg_name=openssh
+pkg_version=7.5p1
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="Provides OpenSSH client and server."
+pkg_license=('bsd')
+pkg_source=http://mirror.wdc1.us.leaseweb.net/openbsd/OpenSSH/portable/${pkg_name}-${pkg_version}.tar.gz
+pkg_shasum=9846e3c5fab9f0547400b4d2c017992f914222b3fd1f8eee6c7dc6bc5e59f9f0
+pkg_upstream_url=https://www.openssh.com/
+pkg_bin_dirs=(bin sbin libexec)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+pkg_deps=(core/glibc core/openssl core/zlib)
+pkg_build_deps=(core/coreutils core/gcc core/make)
+pkg_svc_user="root"
+pkg_svc_group="root"
+
+do_build() {
+  ./configure --prefix="${pkg_prefix}" \
+              --sysconfdir="${pkg_svc_path}/config" \
+              --localstatedir="${pkg_svc_path}/var" \
+              --datadir="${pkg_svc_data_path}" \
+              --with-privsep-user=hab \
+              --with-privsep-path="${pkg_prefix}/var/empty"
+  make
+}
+
+do_install() {
+  make install-nosysconf
+  mkdir -p "${pkg_prefix}/var/empty"
+  chmod 700 "${pkg_prefix}/var/empty"
+}

--- a/plan.sh
+++ b/plan.sh
@@ -27,6 +27,4 @@ do_build() {
 
 do_install() {
   make install-nosysconf
-  mkdir -p "${pkg_prefix}/var/empty"
-  chmod 700 "${pkg_prefix}/var/empty"
 }


### PR DESCRIPTION
All tests are now passing after fixing issue #2: the sshd failed to start in docker until the /var/empty configuration was moved from the plan.sh to the init service hook.

```rspec
hab pkg exec chef/inspec inspec exec /src/. --chef-license=accept -t docker://a01ce9454d4cbde3d3b5be35ab400b3ecb135c6c0574db85bd9b48b262c573df --input-file /src/attributes.yml
+---------------------------------------------+
✔ 1 product license accepted.
+---------------------------------------------+

Profile: Habitat Core Plan openssh (openssh)
Version: 0.1.0
Target:  docker://a01ce9454d4cbde3d3b5be35ab400b3ecb135c6c0574db85bd9b48b262c573df

  ✔  core-plans-openssh-habservice-works: Ensure openssh habitat service works as expected
     ✔  Command: `hab pkg path core/openssh` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/openssh` stdout is expected not to be empty
     ✔  Command: `hab pkg path core/openssh` stderr is expected to be empty
     ✔  Command: `hab svc status` exit_status is expected to eq 0
     ✔  Command: `hab svc status` stdout is expected not to be empty
     ✔  Command: `hab svc status` stdout is expected to match /(?<package>core\/openssh\/7.5p1\/20200611180655)\s+(?<type>standalone)\s+(?<desired>up)\s+(?<state>up)/
     ✔  Command: `hab svc status` stderr is expected to be empty
     ✔  Command: `hab pkg path core/busybox-static` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/busybox-static` stdout is expected not to be empty
     ✔  Command: `hab pkg path core/busybox-static` stderr is expected to be empty
     ✔  Command: `/hab/pkgs/core/busybox-static/1.31.0/20200306011713/bin/netstat -peanut` exit_status is expected to eq 0
     ✔  Command: `/hab/pkgs/core/busybox-static/1.31.0/20200306011713/bin/netstat -peanut` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/core/busybox-static/1.31.0/20200306011713/bin/netstat -peanut` stdout is expected to match /:(?<port>2222).*LISTEN\s+(?<program>-|\d+\/sshd)/
     ✔  Command: `/hab/pkgs/core/busybox-static/1.31.0/20200306011713/bin/netstat -peanut` stderr is expected to be empty
  ✔  core-plans-openssh-works: Ensure openssh works as expected
     ✔  Command: `hab pkg path core/openssh` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/openssh` stdout is expected not to be empty
     ✔  Command: `hab pkg path core/openssh` stderr is expected to be empty
     ✔  Command: `/hab/pkgs/core/openssh/7.5p1/20200611180655/sbin/sshd -V` exit_status is expected to eq 1
     ✔  Command: `/hab/pkgs/core/openssh/7.5p1/20200611180655/sbin/sshd -V` stdout is expected to be empty
     ✔  Command: `/hab/pkgs/core/openssh/7.5p1/20200611180655/sbin/sshd -V` stderr is expected not to be empty
     ✔  Command: `/hab/pkgs/core/openssh/7.5p1/20200611180655/sbin/sshd -V` stderr is expected to match /^OpenSSH_7.5p1/
  ✔  core-plans-openssh-exists: Ensure openssh exists
     ✔  Command: `hab pkg path core/openssh` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/openssh` stdout is expected not to be empty
     ✔  Command: `hab pkg path core/openssh` stderr is expected to be empty
     ✔  File /hab/pkgs/core/openssh/7.5p1/20200611180655/sbin/sshd is expected to exist


Profile Summary: 3 successful controls, 0 control failures, 0 controls skipped
Test Summary: 25 successful, 0 failures, 0 skipped
+ set +x
```